### PR TITLE
handle reply chains among multiple clients by simply running all cut …

### DIFF
--- a/lib/planer.js
+++ b/lib/planer.js
@@ -76,7 +76,7 @@
   //   Must respond to `DOMImplementation.createHTMLDocument()`.
   //   @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument
   exports.extractFromHtml = function(msgBody, dom) {
-    var checkpoint, crlfReplaced, emailDocument, emailDocumentCopy, haveCutQuotations, i, index, k, l, len, len1, line, lineCheckpoints, lines, m, markers, matches, numberOfCheckpoints, plainTextMsg, quotationCheckpoints, ref, ref1, ref2, returnFlags;
+    var checkpoint, crlfReplaced, emailDocument, emailDocumentCopy, haveCutQuotations, haveCutQuotationsBlock, haveCutQuotationsById, haveCutQuotationsFromBlock, haveCutQuotationsGMail, haveCutQuotationsMicrosoft, i, index, k, l, len, len1, line, lineCheckpoints, lines, m, markers, matches, numberOfCheckpoints, plainTextMsg, quotationCheckpoints, ref, ref1, ref2, returnFlags;
     if (dom == null) {
       console.error("No dom provided to parse html.");
       return msgBody;
@@ -86,11 +86,14 @@
     }
     [msgBody, crlfReplaced] = _CRLF_to_LF(msgBody);
     emailDocument = htmlPlaner.createEmailDocument(msgBody, dom);
-    // TODO: this check does not handle cases of emails between various email providers well because
-    // it will find whichever splitter comes first in this list, not necessarily the top-most and stop
-    // checking for others. Possible solution is to use something like compareByDomPosition from htmlPlaner
-    // to find the earliest splitter in the DOM.
-    haveCutQuotations = htmlPlaner.cutGmailQuote(emailDocument) || htmlPlaner.cutBlockQuote(emailDocument) || htmlPlaner.cutMicrosoftQuote(emailDocument) || htmlPlaner.cutById(emailDocument) || htmlPlaner.cutFromBlock(emailDocument);
+    // handle cases of emails between various email providers by running all checks instead of
+    // stopping at whichever check returns positive first
+    haveCutQuotationsGMail = htmlPlaner.cutGmailQuote(emailDocument);
+    haveCutQuotationsBlock = htmlPlaner.cutBlockQuote(emailDocument);
+    haveCutQuotationsMicrosoft = htmlPlaner.cutMicrosoftQuote(emailDocument);
+    haveCutQuotationsById = htmlPlaner.cutById(emailDocument);
+    haveCutQuotationsFromBlock = htmlPlaner.cutFromBlock(emailDocument);
+    haveCutQuotations = haveCutQuotationsGMail || haveCutQuotationsBlock || haveCutQuotationsMicrosoft || haveCutQuotationsById || haveCutQuotationsFromBlock;
     // Create unaltered copy of email document
     emailDocumentCopy = htmlPlaner.createEmailDocument(emailDocument.documentElement.outerHTML, dom);
     // Add checkpoints to html document

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Remove reply quotations from emails",
   "main": "lib/planer.js",
   "publishConfig": {

--- a/src/planer.coffee
+++ b/src/planer.coffee
@@ -78,16 +78,20 @@ exports.extractFromHtml = (msgBody, dom) ->
   [msgBody, crlfReplaced] = _CRLF_to_LF msgBody
   emailDocument = htmlPlaner.createEmailDocument msgBody, dom
 
-  # TODO: this check does not handle cases of emails between various email providers well because
-  # it will find whichever splitter comes first in this list, not necessarily the top-most and stop
-  # checking for others. Possible solution is to use something like compareByDomPosition from htmlPlaner
-  # to find the earliest splitter in the DOM.
+  # handle cases of emails between various email providers by running all checks instead of
+  # stopping at whichever check returns positive first
+  haveCutQuotationsGMail = htmlPlaner.cutGmailQuote(emailDocument)
+  haveCutQuotationsBlock = htmlPlaner.cutBlockQuote(emailDocument)
+  haveCutQuotationsMicrosoft = htmlPlaner.cutMicrosoftQuote(emailDocument)
+  haveCutQuotationsById = htmlPlaner.cutById(emailDocument)
+  haveCutQuotationsFromBlock = htmlPlaner.cutFromBlock(emailDocument)
+  
   haveCutQuotations = (
-    htmlPlaner.cutGmailQuote(emailDocument) ||
-    htmlPlaner.cutBlockQuote(emailDocument) ||
-    htmlPlaner.cutMicrosoftQuote(emailDocument) ||
-    htmlPlaner.cutById(emailDocument) ||
-    htmlPlaner.cutFromBlock(emailDocument)
+      haveCutQuotationsGMail ||
+      haveCutQuotationsBlock ||
+      haveCutQuotationsMicrosoft ||
+      haveCutQuotationsById ||
+      haveCutQuotationsFromBlock
   )
 
   # Create unaltered copy of email document

--- a/test/examples/html/mixedEmailClientReplyChain.html
+++ b/test/examples/html/mixedEmailClientReplyChain.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<title></title>
+</head>
+
+<body dir="ltr">
+
+<div style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);">Here is the answer
+</div>
+<div>
+<div style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><br>
+</div>
+<div id="Signature">
+<div id="divtagdefaultwrapper" dir="ltr" style="color:rgb(0,0,0); font-family:Calibri,Helvetica,sans-serif; font-size:12pt">
+<p style="margin-top:0px; margin-bottom:0px; margin-top:0px; margin-bottom:0px"><span style="font-family:&quot;Times New Roman&quot;,Times,serif">Thomas Smith</span></p>
+</p>
+<p style="margin-top:0px; margin-bottom:0px; margin-top:0px; margin-bottom:0px"><span id="ms-rterangepaste-start"></span></p>
+<span id="ms-rterangepaste-end"></span><br>
+</div>
+</div>
+</div>
+<div id="appendonsend"></div>
+<hr style="display:inline-block;width:98%" tabindex="-1">
+<div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" style="font-size:11pt" color="#000000"><b>From:</b> Bob Smith &lt;bob@smith.com&gt;<br>
+<b>Sent:</b> Monday, April 13, 2020 9:12 AM<br>
+<b>To:</b> My group &lt;thegroup@list.com&gt;<br>
+<b>Subject:</b> Re: [group] Having Trouble</font> 
+<div>&nbsp;</div>
+</div>
+<div>
+ 
+<div dir="ltr">Tom I am having trouble pulling up that case as well. Could someone post or direct me?</div>
+<br>
+<div class="x_gmail_quote">
+<div dir="ltr" class="x_gmail_attr">On Sat, Apr 11, 2020 at 9:51 AM R. Smith &lt;<a href="mailto:group@example.com">group@example.com</a>&gt; wrote:<br>
+</div>
+<blockquote class="x_gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex">
+<div dir="ltr">
+<br>
+<div style="font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0)">Please share, I haven't seen it yet.</div>
+<div>
+<div style="font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt; color:rgb(0,0,0)"><br>
+</div>
+<div id="x_gmail-m_-4046378601710771694Signature">
+<div id="x_gmail-m_-4046378601710771694divtagdefaultwrapper" dir="ltr" style="background-color:rgb(255,255,255)">
+<p style="margin-top:0px; margin-bottom:0px; color:rgb(0,0,0); font-family:Calibri,Arial,Helvetica,sans-serif; font-size:12pt"><span id="x_gmail-m_-4046378601710771694ms-rterangepaste-start"></span></p>
+<div style="text-align:left"><span style="font-family:&quot;Segoe UI&quot;,&quot;Helvetica Neue&quot;,sans-serif; font-size:10pt">R. Smith</span></div>
+<font face="Calibri, Arial, Helvetica, sans-serif"><span id="x_gmail-m_-4046378601710771694ms-rterangepaste-end" style="font-size:12pt"></span></font></div>
+</div>
+</div>
+<div id="x_gmail-m_-4046378601710771694appendonsend"></div>
+<hr style="display:inline-block; width:98%">
+<div id="x_gmail-m_-4046378601710771694divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt"><b>From:</b> Thomas Smith &lt;<a href="mailto:group@example.com" target="_blank">group@example.com</a>&gt;<br>
+<b>Sent:</b> Saturday, April 11, 2020 9:24 AM<br>
+<b>To:</b> My Group &lt;<a href="mailto:thegroup@list.com" target="_blank">thegroup@list.com</a>&gt;<br>
+<b>Subject:</b> Re: [group] Having Trouble</font> 
+<div>&nbsp;</div>
+</div>
+<div style="color:rgb(0,0,0); font-size:14px; font-family:Calibri,sans-serif">
+<br>
+<div>I have gotten past this before.&nbsp;</div>
+<div><br>
+</div>
+<span id="x_gmail-m_-4046378601710771694OLK_SRC_BODY_SECTION"></span> 
+<div style="font-family:Calibri; font-size:11pt; text-align:left; color:black; border-width:1pt medium medium; border-style:solid none none; border-bottom-color:initial; border-left-color:initial; padding:3pt 0in 0in; border-top-color:rgb(181,196,223); border-right-color:initial"><span style="font-weight:bold">From:</span> "Jim Johnson" &lt;<a href="mailto:group@example.com" target="_blank">group@example.com</a>&gt;<br>
+<span style="font-weight:bold">Reply-To:</span> My Group &lt;<a href="mailto:thegroup@list.com" target="_blank">thegroup@list.com</a>&gt;<br>
+<span style="font-weight:bold">Date:</span> Friday, April 17, 2020 at 6:28 PM<br>
+<span style="font-weight:bold">To:</span> My Group &lt;<a href="mailto:thegroup@list.com" target="_blank">thegroup@list.com</a>&gt;<br>
+<span style="font-weight:bold">Subject:</span> [group] Having Trouble<br>
+</div>
+<div><br>
+</div>
+<div>
+<div lang="EN-US">
+<div class="x_gmail-m_-4046378601710771694x_WordSection1">
+<p class="x_gmail-m_-4046378601710771694x_MsoNormal">Anyone had any success on getting past this big problem?</p>
+<p class="x_gmail-m_-4046378601710771694x_MsoNormal">&nbsp;</p>
+<p class="x_gmail-m_-4046378601710771694x_MsoNormal">Jim</p>
+</div>
+<br>
+</div>
+</div>
+<br>
+</div>
+</blockquote>
+</div>
+<br>
+ </div>
+
+</body>
+</html>

--- a/test/planerHtml.test.coffee
+++ b/test/planerHtml.test.coffee
@@ -316,3 +316,17 @@ describe 'planer#extractFromHtml', ->
       expect(extractedHtml).to.exist
       expect(extractedHtml).to.contain(replySnippet)
       expect(extractedHtml).not.to.contain(originalMsgSnippet)
+
+
+    it 'handles emails reply chains involving multiple email clients', ->
+      replySnippet = "Here is the answer"
+      originalMsgSnippet = 'I am having trouble'
+      msgBody = fs.readFileSync(absolutePath('examples/html/mixedEmailClientReplyChain.html'), 'utf8')
+      expect(msgBody).to.contain(replySnippet)
+      expect(msgBody).to.contain(originalMsgSnippet)
+
+      extractedHtml = planer.extractFromHtml(msgBody, @dom)
+
+      expect(extractedHtml).to.exist
+      expect(extractedHtml).to.contain(replySnippet)
+      expect(extractedHtml).not.to.contain(originalMsgSnippet)


### PR DESCRIPTION
## Changes

Removing replies from HTML messages is based on executing a list of email client-specific cut functions.  Previously the code would stop after the first client-specific cut function found something to remove.

This didn't work well when the message had several replies in it and the cut function only removed a portion of the reply chain.

I'm simply running all of the cut functions -- not stopping after the first hit. This comes with a performance penalty, but still allows each cut function to continue to have freedom of implementation -- instead of forcing them to report back the DOM position and using centralized code to remove signature elements.

I bumped the version, with the functionality change.

